### PR TITLE
FIX: Provide figure axis to colorbar

### DIFF
--- a/surfplot/plotting.py
+++ b/surfplot/plotting.py
@@ -450,7 +450,7 @@ class Plot(object):
             
             cb = plt.colorbar(sm, ticks=ticks, location=location, 
                               fraction=fraction, pad=cbar_pads[i], 
-                              shrink=shrink, aspect=aspect)
+                              shrink=shrink, aspect=aspect, ax=plt.gca())
 
             tick_labels = np.linspace(vmin, vmax, n_ticks)
             if decimals > 0:


### PR DESCRIPTION
This should fix #16 

[Relevant matplotlib commit](https://github.com/matplotlib/matplotlib/pull/23740/files#diff-354d00c2540f294d777de7c7d5c51b298fd00850ace7aa0483d1e8d09d99edf3)